### PR TITLE
Set up GitHub Actions workflows for Windows, Mac and Linux releases

### DIFF
--- a/.github/workflows/ci-unix-osx.yaml
+++ b/.github/workflows/ci-unix-osx.yaml
@@ -1,0 +1,54 @@
+name: Build and Release (Mac & Linux)
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  create:
+    # Any branch or tag
+
+jobs:
+  build:
+    name: Build for Linux and Mac
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            os-suffix: darwin
+          - os: ubuntu-latest
+            os-suffix: linux
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Fetch latest evo-luvi version tag
+        # This seems like a hacky way of getting the tag, but I haven't found a better one that "just works"
+        run: curl --location --silent --head --output curl.log -w %{url_effective} https://github.com/evo-lua/evo-luvi/releases/latest | grep --only-matching tag/.* | cut -f2- -d/ | tee LATEST_EVO_LUVI_VERSION && cat curl.log # Print everything, for easier debugging
+
+      - name: Download evo-luvi release
+        run: curl --location --silent --fail --output evo-luvi https://github.com/evo-lua/evo-luvi/releases/download/$(cat LATEST_EVO_LUVI_VERSION)/evo-luvi-${{ matrix.os-suffix }}-amd64 && chmod +x evo-luvi && ./evo-luvi -v # Output version to allow troubleshooting issues more easily if it's wrong
+
+      - name: Clean up temporary files # We don't want to bloat the bundle with these
+        run: rm -v LATEST_EVO_LUVI_VERSION curl.log && mv evo-luvi .. # We still need the runtime, but not in cwd
+
+      - name: Make executable
+        run: ls && ../evo-luvi . -o evo && chmod +x evo && ls && cp evo evo-${{ matrix.os-suffix }}-amd64 && ls
+
+      # We don't want to deploy a faulty release
+      - name: Verify the build
+        run: ./evo Tests/run-all-tests.lua
+
+      - name: Publish new release
+        # Truly "continuous" releases may be overkill here, so better only release tagged versions
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: evo-${{ matrix.os-suffix }}-amd64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,0 +1,52 @@
+name: Build and Release (Windows)
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  create:
+    # Any branch or tag
+
+jobs:
+  build:
+    name: Build for Windows (x64)
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Fetch latest evo-luvi version tag
+        # This seems like a hacky way of getting the tag, but I haven't found a better one that "just works"
+        run: curl --location --silent --head --output curl.log -w %{url_effective} https://github.com/evo-lua/evo-luvi/releases/latest | grep --only-matching tag/.* | cut -f2- -d/ | tee LATEST_EVO_LUVI_VERSION && cat curl.log # Print everything, for easier debugging
+        shell: bash
+
+      - name: Download evo-luvi release
+        run: curl --location --silent --fail --output evo-luvi.exe https://github.com/evo-lua/evo-luvi/releases/download/$(cat LATEST_EVO_LUVI_VERSION)/evo-luvi.exe &&  ls && ./evo-luvi.exe -v # Output version to allow troubleshooting issues more easily if it's wrong
+        shell: bash
+
+      - name: Clean up temporary files # We don't want to bloat the bundle with these
+        run: rm -v LATEST_EVO_LUVI_VERSION curl.log && mv evo-luvi.exe .. # We still need the runtime, but not in cwd
+        shell: bash
+
+      - name: Make executable
+        # Modifiy path so we can use evo-luvi from the parent dir (avoids it getting added to the bundle twice)
+        run: cd .. && dir && evo-luvi evo -o evo/evo.exe && dir && dir evo
+        shell: cmd
+
+      # We don't want to deploy a faulty release
+      - name: Verify the build
+        run: test.cmd
+        shell: cmd
+
+      - name: Publish new release
+        # Truly "continuous" releases may be overkill here, so better only release tagged versions
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: evo.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not too happy with how complicated the workflow turned out to become, and the duplication between Windows/Unix builds. Will have to revisit later and streamline it, but for now getting something running is more important.