### PR TITLE
Add an assertion builtin to spy on function calls

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -37,6 +37,7 @@ globals = {
 	"assertEquals",
 	"assertTrue",
 	"assertFalse",
+	"assertFunctionCalls",
 
 	"Scenario",
 	"TestSuite",

--- a/Core/Builtins/assertions.lua
+++ b/Core/Builtins/assertions.lua
@@ -32,6 +32,28 @@ function assertTrue(conditionToCheck, description)
 	assertEquals(conditionToCheck, true, description)
 end
 
+function assertFunctionCalls(codeUnderTest, hostTable, targetFunctionName, numExpectedInvocations, description)
+	numExpectedInvocations = numExpectedInvocations or 1
+
+	local backupFunctionToCall = hostTable[targetFunctionName]
+	local numActualInvocations = 0
+
+	local function spy(...)
+		numActualInvocations = numActualInvocations + 1
+		DEBUG("Spy called for function " .. targetFunctionName)
+		backupFunctionToCall(...)
+	end
+
+	-- Must restore before asserting anything or unrelated tests may break
+	hostTable[targetFunctionName] = spy
+	codeUnderTest() -- Should call target function x times
+	hostTable[targetFunctionName] = backupFunctionToCall
+
+	assert(numActualInvocations == numExpectedInvocations, description)
+
+end
+
 _G.assertEquals = assertEquals
 _G.assertFalse = assertFalse
 _G.assertTrue = assertTrue
+_G.assertFunctionCalls = assertFunctionCalls

--- a/Tests/Builtins/assertions/assertFunctionCalls.spec.lua
+++ b/Tests/Builtins/assertions/assertFunctionCalls.spec.lua
@@ -1,0 +1,43 @@
+describe("assertFunctionCalls", function()
+
+	local MyModule = {}
+
+	function MyModule:DoSomething()
+	end
+
+	local function callsTargetFunctionOnce()
+		MyModule:DoSomething()
+	end
+
+	local function callsTargetFunctionTwice()
+		MyModule:DoSomething()
+		MyModule:DoSomething()
+	end
+
+	local function neverCallsTargetFunction()
+
+	end
+
+	it("should not raise an error if the code under test calls the target function the expected number of times", function()
+		assertFunctionCalls(callsTargetFunctionTwice, MyModule, "DoSomething", 2)
+	end)
+
+	it("should raise an error if the target function is not called at all", function()
+		local function shouldCallErrorHandler()
+			assertFunctionCalls(neverCallsTargetFunction, MyModule, "DoSomething")
+		end
+
+		local success = pcall(shouldCallErrorHandler)
+		assertFalse(success)
+	end)
+
+	it("should raise an error if the target function isn't called often enough", function()
+		local function shouldCallErrorHandler()
+			assertFunctionCalls(callsTargetFunctionOnce, MyModule, "DoSomething", 2)
+		end
+
+		local success = pcall(shouldCallErrorHandler)
+		assertFalse(success)
+	end)
+
+end)

--- a/unit-tests.lua
+++ b/unit-tests.lua
@@ -1,5 +1,6 @@
 local testCases = {
 	"./Tests/Builtins/assertions/assertEquals.spec.lua",
+	"./Tests/Builtins/assertions/assertFunctionCalls.spec.lua",
 	"./Tests/Extensions/table.spec.lua",
 	"./Tests/Extensions/uv.spec.lua",
 }


### PR DESCRIPTION
This will be useful in unit tests for the TCP server (constructor starts listening), as well as future additions.