### PR TITLE
Add an experimental typeof builtin to support defining tables as classes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -33,6 +33,7 @@ globals = {
 	"printf",
 	"serialize",
 	"transform",
+	"typeof",
 
 	"assertEquals",
 	"assertTrue",

--- a/Core/Builtins/typeof.lua
+++ b/Core/Builtins/typeof.lua
@@ -1,0 +1,11 @@
+local type = type
+
+local function typeof(object)
+	if type(object) ~= "table" then return type(object) end
+
+	if type(object.__className) ~= "string" then return type(object) end
+
+	return object.__className
+end
+
+_G.typeof = typeof

--- a/Tests/Builtins/typeof.spec.lua
+++ b/Tests/Builtins/typeof.spec.lua
@@ -1,0 +1,39 @@
+local ffi = require("ffi")
+local uv = require("uv")
+
+describe("typeof", function()
+
+	it("should return the default Lua type for objects that aren't tables", function()
+		assertEquals(typeof(42), "number")
+		assertEquals(typeof("Hello"), "string")
+		assertEquals(typeof(true), "boolean")
+		assertEquals(typeof(print), "function")
+		assertEquals(typeof(ffi.new("uint8_t")), "cdata")
+		assertEquals(typeof(uv.new_timer()), "userdata")
+		assertEquals(typeof(nil), "nil")
+		assertEquals(typeof(coroutine.running()), "thread")
+	end)
+
+	it("should return the default Lua type for tables without a __className field", function()
+		local tableWithoutClassName = {}
+
+		assertEquals(typeof(tableWithoutClassName), "table")
+	end)
+
+	it("should return the default Lua type for tables with a non-string __className field value", function()
+		local tableWithNonStringClassName = {
+			__className = 42
+		}
+
+		assertEquals(typeof(tableWithNonStringClassName), "table")
+	end)
+
+	it("should return the value of a table's __className field if it's a string value", function()
+		local tableWithStringClassName ={
+			__className = "SomeClassName"
+		}
+
+		assertEquals(typeof(tableWithStringClassName), "SomeClassName")
+	end)
+
+end)

--- a/main.lua
+++ b/main.lua
@@ -51,6 +51,7 @@ function Evo:LoadBuiltins()
 	import("Core/Builtins/log")
 	import("Core/Builtins/serialize")
 	import("Core/Builtins/transform")
+	import("Core/Builtins/typeof")
 end
 
 function Evo:LoadStandardLibraryExtensions()

--- a/unit-tests.lua
+++ b/unit-tests.lua
@@ -1,6 +1,7 @@
 local testCases = {
 	"./Tests/Builtins/assertions/assertEquals.spec.lua",
 	"./Tests/Builtins/assertions/assertFunctionCalls.spec.lua",
+	"./Tests/Builtins/typeof.spec.lua",
 	"./Tests/Extensions/table.spec.lua",
 	"./Tests/Extensions/uv.spec.lua",
 }


### PR DESCRIPTION
Not sure how useful this will be right now, but I have some ideas that require storing more specific type annotations than just the standard Lua types (particularly the very general "table", "userdata", or "cdata" types that don't really help here).