### PR TITLE
Core: Fix import errors when loading from the bundle VFS

### DIFF
--- a/Core/API/Networking/C_Networking.lua
+++ b/Core/API/Networking/C_Networking.lua
@@ -1,11 +1,26 @@
-local TcpClient = import("./TcpClient.lua")
-local TcpServer = import("./TcpServer.lua")
-local TcpSocket = import("./TcpSocket.lua")
+-- Importing via relative paths from the VFS doesn't work due to an error in the path resolution
+-- This is a workaround and should be replaced with relative imports once the issue is resolved
+local TcpClient = _G.TcpClient
+local TcpServer = _G.TcpServer
+local TcpSocket = _G.TcpSocket
+local AsyncHandleMixin = _G.AsyncHandleMixin
+local AsyncStreamMixin = _G.AsyncStreamMixin
+local AsyncSocketMixin = _G.AsyncSocketMixin
 
 local C_Networking = {
 	TcpSocket = TcpSocket,
 	TcpServer = TcpServer,
 	TcpClient = TcpClient,
+	AsyncHandleMixin = AsyncHandleMixin,
+	AsyncStreamMixin = AsyncStreamMixin,
+	AsyncSocketMixin = AsyncSocketMixin,
 }
 
 _G.C_Networking = C_Networking
+
+_G.TcpClient = nil
+_G.TcpServer = nil
+_G.TcpSocket = nil
+_G.AsyncHandleMixin = nil
+_G.AsyncStreamMixin = nil
+_G.AsyncSocketMixin = nil

--- a/Core/API/Networking/TcpClient.lua
+++ b/Core/API/Networking/TcpClient.lua
@@ -2,7 +2,7 @@ local rawget = rawget
 local setmetatable = setmetatable
 local type = type
 
-local TcpSocket = import("./TcpSocket.lua")
+local TcpSocket = _G.TcpSocket -- import("./TcpSocket.lua")
 
 local TcpClient = {}
 
@@ -100,5 +100,7 @@ function TcpClient:TCP_WRITE_FAILED(errorMessage, chunk) DEBUG("[TcpClient] TCP_
 function TcpClient:TCP_CHUNK_RECEIVED(chunk) DEBUG("[TcpClient] TCP_CHUNK_RECEIVED triggered", chunk) end
 function TcpClient:TCP_SESSION_ENDED() DEBUG("[TcpClient] TCP_SESSION_ENDED triggered") end
 function TcpClient:TCP_SOCKET_CLOSED() DEBUG("[TcpClient] TCP_SOCKET_CLOSED triggered") end
+
+_G.TcpClient = TcpClient
 
 return TcpClient

--- a/Core/API/Networking/TcpServer.lua
+++ b/Core/API/Networking/TcpServer.lua
@@ -5,7 +5,7 @@ local setmetatable = setmetatable
 local table_count = table.count
 local type = type
 
-local TcpSocket = import("./TcpSocket.lua")
+local TcpSocket = _G.TcpSocket -- import("./TcpSocket.lua")
 
 local DEFAULT_SERVER_CREATION_OPTIONS = {
 	port = 12345,
@@ -213,5 +213,7 @@ end
 function TcpServer:TCP_CLIENT_READ_ERROR(client, errorMessage)
 	DEBUG("[TcpServer] TCP_CLIENT_READ_ERROR triggered", client, errorMessage)
 end
+
+_G.TcpServer = TcpServer
 
 return TcpServer

--- a/Core/API/Networking/TcpSocket.lua
+++ b/Core/API/Networking/TcpSocket.lua
@@ -3,9 +3,9 @@ local uv = require("uv")
 local setmetatable = setmetatable
 local type = type
 
-local AsyncHandleMixin = import("../../Primitives/AsyncHandleMixin.lua")
-local AsyncStreamMixin = import("../../Primitives/AsyncStreamMixin.lua")
-local AsyncSocketMixin = import("../../Primitives/AsyncSocketMixin.lua")
+local AsyncHandleMixin = _G.AsyncHandleMixin -- import("../../Primitives/AsyncHandleMixin.lua")
+local AsyncStreamMixin = _G.AsyncStreamMixin -- import("../../Primitives/AsyncStreamMixin.lua")
+local AsyncSocketMixin = _G.AsyncSocketMixin -- import("../../Primitives/AsyncSocketMixin.lua")
 
 local TcpSocket = {
 	__className = "TcpSocket",
@@ -68,5 +68,7 @@ function TcpSocket:OnEvent(eventID, ...)
 
 	eventListener(self, eventID, ...)
 end
+
+_G.TcpSocket = TcpSocket
 
 return TcpSocket

--- a/Core/Primitives/AsyncHandleMixin.lua
+++ b/Core/Primitives/AsyncHandleMixin.lua
@@ -33,4 +33,6 @@ function AsyncHandleMixin:GetReadOnlyFileDescriptor() return self.handle:fileno(
 
 function AsyncHandleMixin:GetTypeInfo() return self.handle:handle_get_type() end
 
+_G.AsyncHandleMixin = AsyncHandleMixin
+
 return AsyncHandleMixin

--- a/Core/Primitives/AsyncSocketMixin.lua
+++ b/Core/Primitives/AsyncSocketMixin.lua
@@ -21,4 +21,6 @@ function AsyncSocketMixin:SetWriteQueueSize() return self.handle:write_queue_siz
 
 function AsyncSocketMixin:Reset() return self.handle:close_reset() end
 
+_G.AsyncSocketMixin = AsyncSocketMixin
+
 return AsyncSocketMixin

--- a/Core/Primitives/AsyncStreamMixin.lua
+++ b/Core/Primitives/AsyncStreamMixin.lua
@@ -21,4 +21,6 @@ function AsyncStreamMixin:SetBlockingMode(...) return self.handle:stream_set_blo
 
 function AsyncStreamMixin:GetWriteQueueSize() return self.handle:stream_get_write_queue_size() end
 
+_G.AsyncStreamMixin = AsyncStreamMixin
+
 return AsyncStreamMixin

--- a/main.lua
+++ b/main.lua
@@ -62,6 +62,9 @@ end
 
 function Evo:ExportHighLevelAPI()
 	import("Core/API/C_FileSystem")
+	import("Core/API/Networking/TcpSocket")
+	import("Core/API/Networking/TcpClient")
+	import("Core/API/Networking/TcpServer")
 	import("Core/API/Networking/C_Networking")
 	import("Core/API/C_Testing")
 end
@@ -73,6 +76,9 @@ end
 function Evo:ExportPrimitives()
 	import("Core/Primitives/Scenario.lua")
 	import("Core/Primitives/TestSuite.lua")
+	import("Core/Primitives/AsyncHandleMixin.lua")
+	import("Core/Primitives/AsyncStreamMixin.lua")
+	import("Core/Primitives/AsyncSocketMixin.lua")
 end
 
 function Evo:StartEventLoop()


### PR DESCRIPTION
The import extension (from evo-luvi) currently doesn't support nested imports for bundle paths. Reworking that will take some effort, so in the meantime this change will restore functionality. It's obviously a hack.

Yes, this is bad, but the problem needs to be fixed properly at the source, so there's not much I can do here until the module loading mechanism works properly when loading from the bundle VFS.

See https://github.com/evo-lua/evo-luvi/issues/38 (the root cause)