### PR TITLE
Core: Remove the reliance on a global args export

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,10 +15,6 @@ globals = {
 	"describe",
 	"it",
 
-	-- Builtins
-	--- Luvi
-	"args",
-
 	-- evo-luvi
 	"dump",
 	"path",

--- a/main.lua
+++ b/main.lua
@@ -3,6 +3,8 @@ local Evo = {}
 local uv = require("uv")
 local ffi = require("ffi")
 
+local args = { ... }
+
 function Evo:ProcessUserInput()
 	-- There's always one argument, the runtime itself (but it's stored at index "0", so Lua doesn't count it)
 	local hasCommandLineArguments = (#args > 0)


### PR DESCRIPTION
This nonstandard export has been removed from the runtime. Using the standard varargs way of passing arguments seems more idiomatic, anyway.